### PR TITLE
Update contribute guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+<!-- Thanks for contributing! -->
+
+# Description
+
+<!-- Describe what is your game about. -->
+
+# Checklist
+
+<!-- If you create a pull request but your work is in progress, simply add [WIP] next to pull request name. This make us recognize that your work is not done. -->
+
+<!-- Before proceed, please make sure that you already do as following task: -->
+
+- [ ] Your game is remains in the folder.
+- [ ] The folder contains `index.html` and `info.json`, no additional files included. (except for image/video/font files)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,0 @@
-### Description
-...please describe what you do in this pull request...
-
-Note: if your project is not finish yet and don't want our mod to merge it. Simply add [WIP] next to pull request name. This make us recognize that your work is not done.


### PR DESCRIPTION
I've been concerned that other open-source projects use CONTRIBUTING.md to provide theirs contribute guideline to their contributor.
So I removed the old pull request template and added CONTRIBUTING.md instead.