### PR TITLE
Update year of Bogotetris and update author link

### DIFF
--- a/bogotetris/info.json
+++ b/bogotetris/info.json
@@ -2,6 +2,6 @@
   "name": "BogoTetris",
   "description": "Playing Tetris in a primitive way",
   "author": "spicydog",
-  "facebook": "https://www.facebook.com/kriangkrai.chaonithi",
-  "year": 2010
+  "facebook": "https://spicydog.me",
+  "year": 2020
 }


### PR DESCRIPTION
I found that the year was 2010, so I've updated to 2020.